### PR TITLE
Migrate to workspace-based Application Insights resource

### DIFF
--- a/azure-cli/monitor/deploy.ps1
+++ b/azure-cli/monitor/deploy.ps1
@@ -86,6 +86,7 @@ $output = az monitor app-insights component create `
   --resource-group $resourceGroupName `
   --application-type web `
   --kind web `
+  --workspace $logAnalyticsId `
   --tags $resourceTags
 
 Throw-WhenError -output $output


### PR DESCRIPTION
Migrating to workspace-based Application Insights resource, since Classic Application Insights is Deprecated.