### PR TITLE
Make azure-cli/databricks/deploy.ps1 cross platform

### DIFF
--- a/azure-cli/databricks/deploy.ps1
+++ b/azure-cli/databricks/deploy.ps1
@@ -205,7 +205,7 @@ Enable-SparkMonitoringToLogAnalytics `
 Write-Host "  Setting up pyodbc driver" -ForegroundColor DarkYellow
 
 dbfs mkdirs dbfs:/databricks/drivers
-dbfs cp --overwrite "$PSScriptRoot\utilities\drivers\msodbcsql17_17.7.2.1-1_amd64.deb" dbfs:/databricks/drivers/msodbcsql17_amd64.deb
+dbfs cp --overwrite (Resolve-Path -Relative "$PSScriptRoot\utilities\drivers\msodbcsql17_17.7.2.1-1_amd64.deb") dbfs:/databricks/drivers/msodbcsql17_amd64.deb
 
 Set-DatabricksGlobalInitScript `
   -workspaceUrl $workspaceUrl `

--- a/azure-cli/databricks/deploy.ps1
+++ b/azure-cli/databricks/deploy.ps1
@@ -122,7 +122,7 @@ If ($dbWorkspace.Count -eq 0) {
   Write-Host "  Deploying Databricks template" -ForegroundColor DarkYellow
   $output = az deployment group create `
     --resource-group $resourceGroupName `
-    --template-file "$PSScriptRoot\arm-templates\databricks-workspace.json" `
+    --template-file "databricks/arm-templates/databricks-workspace.json" `
     --parameters workspaceName=$databricksName
 
   Throw-WhenError -output $output


### PR DESCRIPTION
#### This PR makes the path to the pyodbc driver and databricks-workspace.json work in both Linux and Windows.

PowerShell itself is very forgiving about parsing paths with both forward slashes and backslashes, even combined in the same string, but when invoking other shells and tools, we sometimes need to be stricter.

In Databricks CLI we need a correct path. Forward slashes on Linux and backslashes on Windows.

In Azure CLI's `az deployment group create --template-file "<path-to-file>"`, we can use a relative path, but the path must use forward slashes to work on both Linux and Windows.
