### PR TITLE
Better keyvault set secret - handle soft-deleted secrets

### DIFF
--- a/azure-cli/keyvault/recover_KeyVaultSecret.ps1
+++ b/azure-cli/keyvault/recover_KeyVaultSecret.ps1
@@ -1,0 +1,42 @@
+function Recover-KeyVaultSecret {
+  param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $keyVaultName,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $secretName
+  )
+
+  Write-Host "    Recovering $secretName secret"
+  
+  $output = az keyvault secret recover `
+    --vault-name $keyVaultName `
+    --name $secretName
+
+  Throw-WhenError -output $output
+
+  while ($true) {
+    $err = $( $output = az keyvault secret show `
+        --name $secretName `
+        --vault-name $keyVaultName `
+        --query value `
+        --output tsv ) 2>&1
+
+    if ($err) {
+      if ($err -like "*ERROR: (SecretNotFound)*") {
+        Write-Host "    Secret is being recovered. Waiting one second"
+        Start-Sleep -Seconds 1 
+      }
+      else {
+        Throw-WhenError -output $err
+      }
+    }
+    else {
+      break
+    }
+  }
+
+  return $output
+}

--- a/azure-cli/keyvault/remove_KeyVaultSecret.ps1
+++ b/azure-cli/keyvault/remove_KeyVaultSecret.ps1
@@ -1,0 +1,10 @@
+function Remove-KeyVaultSecret {
+  param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $secretId
+  )
+  Write-Host "  Removing '$secretId' secret" -ForegroundColor DarkYellow
+  $output = az keyvault secret delete --id $secretId
+  Throw-WhenError -output $output
+}

--- a/azure-cli/keyvault/set_KeyVaultSecret.ps1
+++ b/azure-cli/keyvault/set_KeyVaultSecret.ps1
@@ -48,12 +48,12 @@ function Set-KeyVaultSecretPlain {
   )
 
   . "$PSScriptRoot\get_KeyVaultSecret.ps1"
-  . "$PSScriptRoot\recoverKeyVaultSecret.ps1"
-  . "$PSScriptRoot\verifyKeyVaultSecret.ps1"
+  . "$PSScriptRoot\recover_KeyVaultSecret.ps1"
+  . "$PSScriptRoot\verify_KeyVaultSecret.ps1"
 
   Write-Host "  Setting $secretName secret" -ForegroundColor DarkYellow
 
-  $alreadySet = VerifyKeyVaultSecret `
+  $alreadySet = Verify-KeyVaultSecret `
     -keyVaultName $keyVaultName `
     -secretName $secretName `
     -secretPlain $secretPlain
@@ -76,7 +76,7 @@ function Set-KeyVaultSecretPlain {
       if ($err -like "*Secret $secretName is currently in a deleted but recoverable state, and its name cannot be reused; in this state, the secret can only be recovered or purged.*") {
         Write-Host "  Secret was soft-deleted. Recovering $secretName secret" -ForegroundColor DarkYellow
 
-        $output = RecoverKeyVaultSecret `
+        $output = Recover-KeyVaultSecret `
           -keyVaultName $keyVaultName `
           -secretName $secretName
 

--- a/azure-cli/keyvault/verify_KeyVaultSecret.ps1
+++ b/azure-cli/keyvault/verify_KeyVaultSecret.ps1
@@ -1,0 +1,32 @@
+function Verify-KeyVaultSecret {
+  param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $keyVaultName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $secretName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $secretPlain
+  )
+
+  $err = $( $output = az keyvault secret show `
+      --name $secretName `
+      --vault-name $keyVaultName `
+      --query value `
+      --output tsv ) 2>&1
+
+  if ($output -eq $secretPlain) {
+    return $true
+  }
+  elseif ($err -like "*(SecretNotFound)*" -or $output -ne $secretPlain) {
+    return $false
+  }
+
+  Throw-WhenError -output $err
+}


### PR DESCRIPTION
This addition adds extra logic to set_KeyVaultSecret which enables it to handle soft deleted secrets automatically by first recovering the secret, and then setting the secret again, if it is different from the recovered secret.

This PR includes a few extra key vault helper functions.