### PR TITLE
Add cmdlet to check if a Key Vault already exists

### DIFF
--- a/azure-cli/keyvault/deploy.ps1
+++ b/azure-cli/keyvault/deploy.ps1
@@ -71,19 +71,15 @@ param (
 . "$PSScriptRoot\get_KeyVaultSecret.ps1"
 . "$PSScriptRoot\set_KeyVaultSecret.ps1"
 . "$PSScriptRoot\set_KeyVaultSPNPolicy.ps1"
+. "$PSScriptRoot\test_KeyVaultExists.ps1"
 
 #############################################################################################
 # Provision Key Vault
 #############################################################################################
 Write-Host "Provision Key Vault" -ForegroundColor DarkGreen
 
-Write-Host "  Query Key Vault" -ForegroundColor DarkYellow
-$output = az keyvault show `
-  --name $keyVaultName `
-  --resource-group $resourceGroupName `
-
-if (!$?) {
-  Write-Host "  Create key vault" -ForegroundColor DarkYellow
+if ((Test-KeyVaultExists -keyVaultName $keyVaultName -resourceGroupName $resourceGroupName) -eq $false) {
+  Write-Host "  Creating key Vault $keyVaultName" -ForegroundColor DarkYellow
   $output = az keyvault create `
     --name $keyVaultName `
     --location $location `
@@ -106,9 +102,6 @@ if (!$?) {
       Throw-WhenError -output $output
     }
   }
-}
-else {
-  Write-Host "  Key vault already exists, skipping creation" -ForegroundColor DarkYellow
 }
 
 Throw-WhenError -output $output

--- a/azure-cli/keyvault/test_KeyVaultExists.ps1
+++ b/azure-cli/keyvault/test_KeyVaultExists.ps1
@@ -1,0 +1,22 @@
+function Test-KeyVaultExists {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $keyVaultName,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $resourceGroupName
+    )
+
+    Write-Host "  Checking for existing '$keyVaultName' Key Vault" -ForegroundColor DarkYellow
+    $output = az keyvault list `
+        --resource-group $resourceGroupName `
+        --resource-type vault --query "contains([].name, '$keyVaultName')"
+
+    Throw-WhenError -output $output
+
+    Write-Host "    Key Vault already exists: $output"
+
+    return [System.Convert]::ToBoolean($output)
+}


### PR DESCRIPTION
`az keyvault list` is faster than `az keyvault show` and won't return wonky errors when the key vault does not exist