### PR TITLE
Correct parameter name

### DIFF
--- a/azure-cli/storage/get_StorageAccountConnection.ps1
+++ b/azure-cli/storage/get_StorageAccountConnection.ps1
@@ -6,7 +6,7 @@ function Get-StorageConnectionString {
 
     [Parameter(Mandatory = $true)]
     [string]
-    $resourceGroup
+    $resourceGroupName
   )
 
   Write-Host "  Get Storage Account connection string for $storageAccountName" -ForegroundColor DarkYellow


### PR DESCRIPTION
Use the correct parameter name.