### PR TITLE
Fix Initialize-AppServicePlan return statement placed in wrong scope

### DIFF
--- a/azure-cli/appservice/Initialize-AppServicePlan.ps1
+++ b/azure-cli/appservice/Initialize-AppServicePlan.ps1
@@ -81,7 +81,7 @@ function Initialize-AppServicePlan {
 
       $appServicePlanId = $appServicePlanResource.id
     }
-
-    return $appServicePlanId
   }
+
+  return $appServicePlanId
 }


### PR DESCRIPTION
The return statement was missplaced inside an `else` statement causing the function to only return the App Service plan resource ID when the App Service plan resource already existed