### PR TITLE
Update an Add new Active Directory script to setup app registartion and access

### DIFF
--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -1,10 +1,12 @@
 function Add-ClientToServicePrincipal {
   param (
     [Parameter(Mandatory = $true)]
-    [EnvironmentConfig] $environmentConfig,
+    [EnvironmentConfig]
+    $environmentConfig,
 
     [Parameter(Mandatory = $true)]
-    [NamingConfig] $namingConfig,
+    [NamingConfig]
+    $namingConfig,
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('api', 'spn', 'app', 'https')]
@@ -26,8 +28,8 @@ function Add-ClientToServicePrincipal {
     -namingConfig $namingConfig
 
   $appId = az ad app list `
-      --identifier-uri $appIdentityId `
-      --query [-1].id
+    --identifier-uri $appIdentityId `
+    --query [-1].id
 
   $graphApiUri = "https://graph.microsoft.com/v1.0/applications/" + $appId
   $properties = az rest --method get --uri $graphApiUri | ConvertFrom-Json

--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -31,6 +31,8 @@ function Add-ClientToServicePrincipal {
     --identifier-uri $appIdentityId `
     --query [-1].id
 
+  Write-Host "  Assigning Client pre-authorized access to App Registration" -ForegroundColor DarkYellow
+
   $graphApiUri = "https://graph.microsoft.com/v1.0/applications/" + $appId
   $properties = az rest --method get --uri $graphApiUri | ConvertFrom-Json
 

--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -1,0 +1,34 @@
+function Add-ClientToServicePrincipal {
+  param (
+    [Parameter(Mandatory = $true)]
+    [EnvironmentConfig] $environmentConfig,
+
+    [Parameter(Mandatory = $true)]
+    [NamingConfig] $namingConfig,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $applicationId
+  )
+
+  # import utility functions
+  . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
+
+  $appIdentityId = Get-AppIdentityUri `
+      -type "api" `
+      -environmentConfig $environmentConfig `
+      -namingConfig $namingConfig
+
+  $appId = az ad app list `
+      --identifier-uri $appIdentityId `
+      --query [-1].id
+
+  $graphApiUri = "https://graph.microsoft.com/v1.0/applications/" + $appId
+  $properties = az rest --method get --uri $graphApiUri | ConvertFrom-Json
+
+  $scopeAppId = $properties.api.oauth2PermissionScopes.id
+  $body = '{""api"": {""preAuthorizedApplications"": [{""appId"": ""' + $applicationId + '"",""delegatedPermissionIds"": [""' + $scopeAppId + '""]}]}}'
+
+  az rest --method patch --uri $graphApiUri --headers "Content-Type=application/json" --body $body
+}

--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -6,7 +6,12 @@ function Add-ClientToServicePrincipal {
     [Parameter(Mandatory = $true)]
     [NamingConfig] $namingConfig,
 
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('api', 'spn', 'app', 'https')]
+    [string]
+    $appType = "api",
+
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]
     $applicationId
@@ -16,9 +21,9 @@ function Add-ClientToServicePrincipal {
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
   $appIdentityId = Get-AppIdentityUri `
-      -type "api" `
-      -environmentConfig $environmentConfig `
-      -namingConfig $namingConfig
+    -type $appType `
+    -environmentConfig $environmentConfig `
+    -namingConfig $namingConfig
 
   $appId = az ad app list `
       --identifier-uri $appIdentityId `

--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -2,30 +2,30 @@ function Add-ClientToServicePrincipal {
   param (
     [Parameter(Mandatory = $true)]
     [EnvironmentConfig]
-    $environmentConfig,
+    $EnvironmentConfig,
 
     [Parameter(Mandatory = $true)]
     [NamingConfig]
-    $namingConfig,
+    $NamingConfig,
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('api', 'spn', 'app', 'https')]
     [string]
-    $appType = "api",
+    $AppType = "api",
 
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]
-    $applicationId
+    $ApplicationId
   )
 
   # import utility functions
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
   $appIdentityId = Get-AppIdentityUri `
-    -type $appType `
-    -environmentConfig $environmentConfig `
-    -namingConfig $namingConfig
+    -type $AppType `
+    -environmentConfig $EnvironmentConfig `
+    -namingConfig $NamingConfig
 
   $appId = az ad app list `
     --identifier-uri $appIdentityId `
@@ -35,7 +35,7 @@ function Add-ClientToServicePrincipal {
   $properties = az rest --method get --uri $graphApiUri | ConvertFrom-Json
 
   $scopeAppId = $properties.api.oauth2PermissionScopes.id
-  $body = '{""api"": {""preAuthorizedApplications"": [{""appId"": ""' + $applicationId + '"",""delegatedPermissionIds"": [""' + $scopeAppId + '""]}]}}'
+  $body = '{""api"": {""preAuthorizedApplications"": [{""appId"": ""' + $ApplicationId + '"",""delegatedPermissionIds"": [""' + $scopeAppId + '""]}]}}'
 
   az rest --method patch --uri $graphApiUri --headers "Content-Type=application/json" --body $body
 }

--- a/azure-cli/ad/Add-GroupToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-GroupToServicePrincipal.ps1
@@ -1,30 +1,32 @@
-function Add-GroupToServicePrincipal(
-  [Parameter(Mandatory = $true)]
-  [EnvironmentConfig]
-  $EnvironmentConfig,
+function Add-GroupToServicePrincipal {
+  param(
+    [Parameter(Mandatory = $true)]
+    [EnvironmentConfig]
+    $EnvironmentConfig,
 
-  [Parameter(Mandatory = $true)]
-  [NamingConfig]
-  $NamingConfig,
+    [Parameter(Mandatory = $true)]
+    [NamingConfig]
+    $NamingConfig,
 
-  [Parameter(Mandatory = $false)]
-  [ValidateSet('api', 'spn', 'app', 'https')]
-  [string]
-  $appType = "api",
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('api', 'spn', 'app', 'https')]
+    [string]
+    $AppType = "api",
 
-  [Parameter(Mandatory = $true)]
-  [string]
-  $GroupId,
+    [Parameter(Mandatory = $true)]
+    [string]
+    $GroupId,
 
-  [Parameter(Mandatory = $false)]
-  [string]
-  $ServiceInstance
-) {
+    [Parameter(Mandatory = $false)]
+    [string]
+    $ServiceInstance
+  )
+
   # import utility functions
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
   $spnAppIdentityName = Get-AppIdentityDisplayName `
-    -type $appType `
+    -type $AppType `
     -environmentConfig $EnvironmentConfig `
     -namingConfig $NamingConfig `
     -serviceInstance $ServiceInstance

--- a/azure-cli/ad/Add-GroupToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-GroupToServicePrincipal.ps1
@@ -19,8 +19,7 @@ function Add-GroupToServicePrincipal(
   [Parameter(Mandatory = $false)]
   [string]
   $ServiceInstance
-)
-{
+) {
   # import utility functions
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
@@ -32,24 +31,27 @@ function Add-GroupToServicePrincipal(
 
   $objectId = az ad sp list --display-name $spnAppIdentityName --query [0].id
 
-    $existingAssignments = az rest `
-        --method GET `
-        --url "https://graph.microsoft.com/v1.0/servicePrincipals/$objectId/appRoleAssignedTo" `
-        --headers "Content-Type=application/json" ` `
-        | ConvertFrom-Json
+  Write-Host "Assigning Group access to App Registration" -ForegroundColor DarkGreen
 
-    Throw-WhenError -output $existingAssignments
+  $existingAssignments = az rest `
+    --method GET `
+    --url "https://graph.microsoft.com/v1.0/servicePrincipals/$objectId/appRoleAssignedTo" `
+    --headers "Content-Type=application/json" ` `
+  | ConvertFrom-Json
 
-    if ($existingAssignments.value.principalId -eq $groupId ) {
-      Write-Host "  Group already has access to the Service Principal" -ForegroundColor DarkYellow
-    } else {
-      Write-Host "  Grant group access to Service Principal" -ForegroundColor DarkYellow
-      $output = az rest `
-          --method POST `
-          --url "https://graph.microsoft.com/v1.0/servicePrincipals/$objectId/appRoleAssignedTo" `
-          --headers "Content-Type=application/json" `
-          --body "{\""resourceId\"":\""$objectId\"",\""principalId\"":\""$groupId\""}"
+  Throw-WhenError -output $existingAssignments
 
-      Throw-WhenError -output $output
-    }
+  if ($existingAssignments.value.principalId -eq $groupId) {
+    Write-Host "  Group already has access to the Service Principal" -ForegroundColor DarkYellow
+  }
+  else {
+    Write-Host "  Grant group access to Service Principal" -ForegroundColor DarkYellow
+    $output = az rest `
+      --method POST `
+      --url "https://graph.microsoft.com/v1.0/servicePrincipals/$objectId/appRoleAssignedTo" `
+      --headers "Content-Type=application/json" `
+      --body "{""resourceId"":""$objectId"",""principalId"":""$groupId""}"
+
+    Throw-WhenError -output $output
+  }
 }

--- a/azure-cli/ad/Add-GroupToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-GroupToServicePrincipal.ps1
@@ -33,7 +33,7 @@ function Add-GroupToServicePrincipal {
 
   $objectId = az ad sp list --display-name $spnAppIdentityName --query [0].id
 
-  Write-Host "Assigning Group access to App Registration" -ForegroundColor DarkGreen
+  Write-Host "  Assigning Group access to App Registration" -ForegroundColor DarkYellow -NoNewline
 
   $existingAssignments = az rest `
     --method GET `
@@ -44,10 +44,10 @@ function Add-GroupToServicePrincipal {
   Throw-WhenError -output $existingAssignments
 
   if ($existingAssignments.value.principalId -eq $groupId) {
-    Write-Host "  Group already has access to the Service Principal" -ForegroundColor DarkYellow
+    Write-Host " -> Group already has access to the Service Principal" -ForegroundColor Cyan
   }
   else {
-    Write-Host "  Grant group access to Service Principal" -ForegroundColor DarkYellow
+    Write-Host " -> Grant group access to Service Principal" -ForegroundColor Cyan
     $output = az rest `
       --method POST `
       --url "https://graph.microsoft.com/v1.0/servicePrincipals/$objectId/appRoleAssignedTo" `

--- a/azure-cli/ad/Add-GroupToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-GroupToServicePrincipal.ps1
@@ -7,6 +7,11 @@ function Add-GroupToServicePrincipal(
   [NamingConfig]
   $NamingConfig,
 
+  [Parameter(Mandatory = $false)]
+  [ValidateSet('api', 'spn', 'app', 'https')]
+  [string]
+  $appType = "api",
+
   [Parameter(Mandatory = $true)]
   [string]
   $GroupId,
@@ -20,7 +25,7 @@ function Add-GroupToServicePrincipal(
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
   $spnAppIdentityName = Get-AppIdentityDisplayName `
-    -type "api" `
+    -type $appType `
     -environmentConfig $EnvironmentConfig `
     -namingConfig $NamingConfig `
     -serviceInstance $ServiceInstance

--- a/azure-cli/ad/Add-GroupToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-GroupToServicePrincipal.ps1
@@ -30,7 +30,7 @@ function Add-GroupToServicePrincipal(
     -namingConfig $NamingConfig `
     -serviceInstance $ServiceInstance
 
-  $objectId = az ad sp list --display-name $spnAppIdentityName --query [0].objectId
+  $objectId = az ad sp list --display-name $spnAppIdentityName --query [0].id
 
     $existingAssignments = az rest `
         --method GET `

--- a/azure-cli/ad/Add-MsiAccess.ps1
+++ b/azure-cli/ad/Add-MsiAccess.ps1
@@ -8,7 +8,7 @@ function Add-MsiAccess(
   [Parameter(Mandatory = $false)]
   [ValidateSet('api', 'spn', 'app', 'https')]
   [string]
-  $appType = "app",
+  $appType = "api",
 
   [Parameter(Mandatory=$true)]
   [ValidateNotNullOrEmpty()]

--- a/azure-cli/ad/Add-MsiAccess.ps1
+++ b/azure-cli/ad/Add-MsiAccess.ps1
@@ -44,9 +44,9 @@ function Add-MsiAccess {
 
   Throw-WhenError -output $roles
 
-    Write-Host "Assigning all available roles"
   if ($null -eq $RequiredRoles) {
     $RequiredRoles = @("include-all")
+    Write-Host "  Assigning all available roles" -ForegroundColor DarkYellow
   }
 
   $existingAssignments = (az rest `
@@ -61,8 +61,10 @@ function Add-MsiAccess {
     foreach ($role in $roles) {
       if ($roleValue -eq $role.value -or $roleValue -eq "include-all") {
 
+        Write-Host "  Assigning $($role.value) " -ForegroundColor DarkYellow -NoNewline
+
         if ($existingAssignments.appRoleId -contains $($role.id)) {
-          Write-Host "  API Permission $($role.value) already assigned" -ForegroundColor DarkYellow
+          Write-Host " -> Already assigned" -ForegroundColor Cyan
         }
         else {
           $output = az rest `
@@ -72,6 +74,8 @@ function Add-MsiAccess {
           --headers "Content-Type=application/json"
 
           Throw-WhenError -output $output
+
+          Write-Host " -> Permission assigned" -ForegroundColor Cyan
         }
       }
     }

--- a/azure-cli/ad/Add-MsiAccess.ps1
+++ b/azure-cli/ad/Add-MsiAccess.ps1
@@ -1,0 +1,75 @@
+function Add-MsiAccess(
+  [Parameter(Mandatory = $true)]
+  [EnvironmentConfig] $environmentConfig,
+
+  [Parameter(Mandatory = $true)]
+  [NamingConfig] $namingConfig,
+
+  [Parameter(Mandatory = $false)]
+  [ValidateSet('api', 'spn', 'app', 'https')]
+  [string]
+  $appType = "app",
+
+  [Parameter(Mandatory=$true)]
+  [ValidateNotNullOrEmpty()]
+  [string]
+  $msiId,
+
+  [Parameter(Mandatory=$false)]
+  [string[]]
+  $requiredRoles = $null
+) {
+
+  # import utility functions
+  . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
+
+  $appUri = Get-AppIdentityUri `
+    -type $appType `
+    -environmentConfig $environmentConfig `
+    -namingConfig $namingConfig
+  $spnId = az ad sp list `
+    --spn $appUri `
+    --query [-1].id
+
+  Throw-WhenError -output $spnId
+
+  $roles = az ad sp show `
+      --id $spnId `
+      --query appRoles `
+      | ConvertFrom-Json
+
+  Throw-WhenError -output $roles
+
+  if ($null -eq $requiredRoles) {
+    $requiredRoles = @("include-all")
+    Write-Host "Assigning all available roles"
+  }
+
+  $existingAssignments = (az rest `
+    --method GET `
+    --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$msiId/appRoleAssignments?`$filter=resourceId eq $spnId" `
+    --headers 'Content-Type=application/json' `
+    | ConvertFrom-Json).value
+
+  Throw-WhenError -output $existingAssignments
+
+  foreach ($roleValue in $requiredRoles) {
+    foreach ($role in $roles) {
+      if ($roleValue -eq $role.value -or $roleValue -eq "include-all") {
+
+        if ($existingAssignments.appRoleId -contains $($role.id)){
+          Write-Host "API Permission $($role.value) Already Assigned"
+        } else {
+          Write-Host "Assign API Permission $($role.value)"
+          $output = az rest `
+          --method POST `
+          --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$msiId/appRoleAssignments" `
+          --body "{\`"appRoleId\`": \`"$($role.id)\`",\`"principalId\`": \`"$msiId\`",\`"resourceId\`": \`"$spnId\`"}" `
+          --headers 'Content-Type=application/json'
+
+          Throw-WhenError -output $output
+        }
+      }
+    }
+  }
+}

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -13,6 +13,8 @@ function Add-OAuthUserImpersonationScope {
 
   Throw-WhenError -output $existingManifest
 
+  Write-Host "  Adding 'user_impersonation' scope to App Registration" -ForegroundColor DarkYellow -NoNewline
+
   $existingPermissionScopes = $existingManifest.api.oauth2PermissionScopes
   $existingScope = $existingPermissionScopes | Where-Object { $_.value -eq "user_impersonation" }
 
@@ -45,5 +47,10 @@ function Add-OAuthUserImpersonationScope {
       --body `@manifest.json
 
     Throw-WhenError -output $output
+
+    Write-Host " -> 'user_impersonation' scope added" -ForegroundColor Cyan
+  }
+  else {
+    Write-Host " -> App registration already has 'user_impersonation' scope" -ForegroundColor Cyan
   }
 }

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -1,0 +1,49 @@
+function Add-OAuthUserImpersonationScope(
+    [Parameter(Mandatory = $true)]
+    [string] $spnId
+) {
+  # import utility functions
+  . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
+
+  $existingManifest = az rest `
+    --method Get `
+    --url https://graph.microsoft.com/v1.0/applications/$spnId `
+    --headers "Content-Type=application/json" `
+    | ConvertFrom-Json
+
+  Throw-WhenError -output $existingManifest
+
+  $existingPermissionScopes = $existingManifest.api.oauth2PermissionScopes
+  $existingScope = $existingPermissionScopes | Where-Object {$_.value -eq "user_impersonation"}
+
+  if ($null -eq $existingScope){
+    $newScope = @{
+      adminConsentDescription = "Allow the application to access $($existingManifest.displayName) on behalf of the signed-in user."
+      adminConsentDisplayName = "Access $($existingManifest.displayName)"
+      id = $([System.guid]::NewGuid().toString())
+      isEnabled = $true
+      type = "User"
+      userConsentDescription = "Allow the application to access $($existingManifest.displayName) on your behalf."
+      userConsentDisplayName = "Access $($existingManifest.displayName)"
+      value = "user_impersonation"
+    }
+
+    $existingPermissionScopes += $newScope
+
+    $body = @{
+      api = @{
+        oauth2PermissionScopes = $existingPermissionScopes
+      }
+    } | ConvertTo-Json -Depth 4
+
+    Set-Content ./manifest.json $body
+
+    az rest `
+      --method patch `
+      --url https://graph.microsoft.com/v1.0/applications/$spnId `
+      --headers "Content-Type=application/json" `
+      --body `@manifest.json
+
+    Throw-WhenError -output $output
+  }
+}

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -1,12 +1,13 @@
-function Add-OAuthUserImpersonationScope(
-  [Parameter(Mandatory = $true)]
-  [string]
-  $spnId
-) {
+function Add-OAuthUserImpersonationScope {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $SpnId
+  )
 
   $existingManifest = az rest `
     --method Get `
-    --url https://graph.microsoft.com/v1.0/applications/$spnId `
+    --url https://graph.microsoft.com/v1.0/applications/$SpnId `
     --headers "Content-Type=application/json" `
   | ConvertFrom-Json
 
@@ -19,7 +20,7 @@ function Add-OAuthUserImpersonationScope(
     $newScope = @{
       adminConsentDescription = "Allow the application to access $($existingManifest.displayName) on behalf of the signed-in user."
       adminConsentDisplayName = "Access $($existingManifest.displayName)"
-      id                      = $([System.guid]::NewGuid().toString())
+      id                      = [System.guid]::NewGuid().toString()
       isEnabled               = $true
       type                    = "User"
       userConsentDescription  = "Allow the application to access $($existingManifest.displayName) on your behalf."
@@ -39,7 +40,7 @@ function Add-OAuthUserImpersonationScope(
 
     az rest `
       --method patch `
-      --url https://graph.microsoft.com/v1.0/applications/$spnId `
+      --url https://graph.microsoft.com/v1.0/applications/$SpnId `
       --headers "Content-Type=application/json" `
       --body `@manifest.json
 

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -1,31 +1,30 @@
 function Add-OAuthUserImpersonationScope(
-    [Parameter(Mandatory = $true)]
-    [string] $spnId
+  [Parameter(Mandatory = $true)]
+  [string]
+  $spnId
 ) {
-  # import utility functions
-  . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
 
   $existingManifest = az rest `
     --method Get `
     --url https://graph.microsoft.com/v1.0/applications/$spnId `
     --headers "Content-Type=application/json" `
-    | ConvertFrom-Json
+  | ConvertFrom-Json
 
   Throw-WhenError -output $existingManifest
 
   $existingPermissionScopes = $existingManifest.api.oauth2PermissionScopes
-  $existingScope = $existingPermissionScopes | Where-Object {$_.value -eq "user_impersonation"}
+  $existingScope = $existingPermissionScopes | Where-Object { $_.value -eq "user_impersonation" }
 
-  if ($null -eq $existingScope){
+  if ($null -eq $existingScope) {
     $newScope = @{
       adminConsentDescription = "Allow the application to access $($existingManifest.displayName) on behalf of the signed-in user."
       adminConsentDisplayName = "Access $($existingManifest.displayName)"
-      id = $([System.guid]::NewGuid().toString())
-      isEnabled = $true
-      type = "User"
-      userConsentDescription = "Allow the application to access $($existingManifest.displayName) on your behalf."
-      userConsentDisplayName = "Access $($existingManifest.displayName)"
-      value = "user_impersonation"
+      id                      = $([System.guid]::NewGuid().toString())
+      isEnabled               = $true
+      type                    = "User"
+      userConsentDescription  = "Allow the application to access $($existingManifest.displayName) on your behalf."
+      userConsentDisplayName  = "Access $($existingManifest.displayName)"
+      value                   = "user_impersonation"
     }
 
     $existingPermissionScopes += $newScope


### PR DESCRIPTION
This PR updates the existing Add-GroupToServicePrincipal.ps1 with the latest breaking changes to Microsoft Graph and az cli. This include a breaking change where API endpoint fails if the assignment already exist. The script now checks if the assignment already exist.

The PR also introduces 3 new scripts:
 - `Add-ClientToServicePrincipal.ps1` - Script to grant clients pre-approved access to an application. Mostly used to grant Visual Studio access to allow for local testing.
 - `Add-MsiAccess.ps1` - Script to add a manage identity access to the current service.
 - `Add-OAuthUserImpersonationScope.ps1` - Script to add user_impersonation scope to app registration. This was previously default behavior when creating an app registration.