### PR TITLE
Fix invalid json request body in AD scripts

### DIFF
--- a/azure-cli/ad/Add-ClientToServicePrincipal.ps1
+++ b/azure-cli/ad/Add-ClientToServicePrincipal.ps1
@@ -21,6 +21,7 @@ function Add-ClientToServicePrincipal {
 
   # import utility functions
   . "$PSScriptRoot\..\utilities\deploy.naming.ps1"
+  . "$PSScriptRoot\..\utilities\deploy.utilities.ps1"
 
   $appIdentityId = Get-AppIdentityUri `
     -type $AppType `
@@ -29,15 +30,39 @@ function Add-ClientToServicePrincipal {
 
   $appId = az ad app list `
     --identifier-uri $appIdentityId `
-    --query [-1].id
+    --query [-1].id `
+    --out tsv
 
-  Write-Host "  Assigning Client pre-authorized access to App Registration" -ForegroundColor DarkYellow
+  Throw-WhenError -output $appId
 
-  $graphApiUri = "https://graph.microsoft.com/v1.0/applications/" + $appId
-  $properties = az rest --method get --uri $graphApiUri | ConvertFrom-Json
+  Write-Host "  Assigning Client pre-authorized access to App Registration" -ForegroundColor DarkYellow -NoNewline
 
-  $scopeAppId = $properties.api.oauth2PermissionScopes.id
-  $body = '{""api"": {""preAuthorizedApplications"": [{""appId"": ""' + $ApplicationId + '"",""delegatedPermissionIds"": [""' + $scopeAppId + '""]}]}}'
+  $graphApiUri = "https://graph.microsoft.com/v1.0/applications/$appId"
+  $properties = az rest `
+    --method GET `
+    --uri $graphApiUri `
+    --headers "Content-Type=application/json" `
+    | ConvertFrom-Json
 
-  az rest --method patch --uri $graphApiUri --headers "Content-Type=application/json" --body $body
+  Throw-WhenError -output $properties
+
+  $body = @{
+    api = @{
+      preAuthorizedApplications = @(
+        @{
+          appId = $ApplicationId
+          delegatedPermissionIds = @( $properties.api.oauth2PermissionScopes.id )
+        }
+      )
+    }
+  }
+
+  $output =  az rest `
+    --method PATCH `
+    --uri $graphApiUri `
+    --headers "Content-Type=application/json" `
+    --body (ConvertTo-RequestJson $body -Depth 5)
+
+    Throw-WhenError -output $output
+    Write-Host " -> Pre-authorization assigned" -ForegroundColor Cyan
 }

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -45,7 +45,7 @@ function Add-OAuthUserImpersonationScope {
       --method PATCH `
       --url "https://graph.microsoft.com/v1.0/applications/$SpnId" `
       --headers "Content-Type=application/json" `
-      --body (ConvertTo-RequestJson $body)
+      --body (ConvertTo-RequestJson $body -Depth 4)
 
     Throw-WhenError -output $output
 

--- a/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
+++ b/azure-cli/ad/Add-OAuthUserImpersonationScope.ps1
@@ -5,9 +5,12 @@ function Add-OAuthUserImpersonationScope {
     $SpnId
   )
 
+  # import utility functions
+  . "$PSScriptRoot\..\utilities\deploy.utilities.ps1"
+
   $existingManifest = az rest `
-    --method Get `
-    --url https://graph.microsoft.com/v1.0/applications/$SpnId `
+    --method GET `
+    --url "https://graph.microsoft.com/v1.0/applications/$SpnId" `
     --headers "Content-Type=application/json" `
   | ConvertFrom-Json
 
@@ -36,15 +39,13 @@ function Add-OAuthUserImpersonationScope {
       api = @{
         oauth2PermissionScopes = $existingPermissionScopes
       }
-    } | ConvertTo-Json -Depth 4
+    }
 
-    Set-Content ./manifest.json $body
-
-    az rest `
-      --method patch `
-      --url https://graph.microsoft.com/v1.0/applications/$SpnId `
+    $output = az rest `
+      --method PATCH `
+      --url "https://graph.microsoft.com/v1.0/applications/$SpnId" `
       --headers "Content-Type=application/json" `
-      --body `@manifest.json
+      --body (ConvertTo-RequestJson $body)
 
     Throw-WhenError -output $output
 

--- a/azure-cli/utilities/deploy.utilities.ps1
+++ b/azure-cli/utilities/deploy.utilities.ps1
@@ -30,3 +30,17 @@ function ConvertTo-Base64String {
   $bytes = [System.Text.Encoding]::UTF8.GetBytes($text)
   return [System.Convert]::ToBase64String($bytes)
 }
+
+function ConvertTo-RequestJson {
+  param (
+    [Parameter(ValueFromPipeline, Mandatory = $true)]
+    [object]
+    $Object,
+
+    [Parameter(Mandatory = $false)]
+    [int]
+    $Depth = 4
+  )
+
+  return $Object | ConvertTo-Json -Compress -Depth $Depth | ForEach-Object {$_.Replace('"', '\"')}
+}

--- a/azure-cli/utilities/deploy.utilities.ps1
+++ b/azure-cli/utilities/deploy.utilities.ps1
@@ -39,7 +39,7 @@ function ConvertTo-RequestJson {
 
     [Parameter(Mandatory = $false)]
     [int]
-    $Depth = 4
+    $Depth = 2
   )
 
   return $Object | ConvertTo-Json -Compress -Depth $Depth | ForEach-Object {$_.Replace('"', '\"')}


### PR DESCRIPTION
This PR fixes the newly added AD script to send "valid" json.

The script now construct the json body from a PS object and convert it to a compressed json object with escaped quotes.

In addition, some missing Throw-WhenError were added and minor improvement to logging