### PR TITLE
Add New-Password function

### DIFF
--- a/azure-cli/sql/deploy.ps1
+++ b/azure-cli/sql/deploy.ps1
@@ -62,7 +62,7 @@ $sqlServerPassword = az keyvault secret show `
 
 if (!$?) {
   Write-Host "  Creating SqlServerPassword secret" -ForegroundColor DarkYellow
-  $sqlServerPassword = New-Password -Length 20
+  $sqlServerPassword = New-Password -Length 20 -AvoidCharacters "'"
   $output = az keyvault secret set `
     --vault-name $keyVaultName `
     --name "SqlServerPassword" `
@@ -91,7 +91,7 @@ foreach ($sqlDatabase in $sqlDatabases) {
 
     if ($LastExitCode -gt 0) {
       Write-Host "  Creating $passwordName secret" -ForegroundColor DarkYellow
-      $password = New-Password -Length 20
+      $password = New-Password -Length 20 -AvoidCharacters "'"
       $output = az keyvault secret set `
         --vault-name $keyVaultName `
         --name $passwordName `

--- a/azure-cli/sql/deploy.ps1
+++ b/azure-cli/sql/deploy.ps1
@@ -34,7 +34,7 @@ param (
 Write-Host "Provision Azure SQL server" -ForegroundColor DarkGreen
 
 # import utility functions
-. "$PSScriptRoot\..\_common\utilities\get_NewPassword.ps1"
+. "$PSScriptRoot\..\utilities\New-Password.ps1"
 . "$PSScriptRoot\get_SqlConnectionString.ps1"
 
 #############################################################################################
@@ -62,7 +62,7 @@ $sqlServerPassword = az keyvault secret show `
 
 if (!$?) {
   Write-Host "  Creating SqlServerPassword secret" -ForegroundColor DarkYellow
-  $sqlServerPassword = Get-NewPassword
+  $sqlServerPassword = New-Password -Length 20
   $output = az keyvault secret set `
     --vault-name $keyVaultName `
     --name "SqlServerPassword" `
@@ -91,7 +91,7 @@ foreach ($sqlDatabase in $sqlDatabases) {
 
     if ($LastExitCode -gt 0) {
       Write-Host "  Creating $passwordName secret" -ForegroundColor DarkYellow
-      $password = Get-NewPassword
+      $password = New-Password -Length 20
       $output = az keyvault secret set `
         --vault-name $keyVaultName `
         --name $passwordName `

--- a/azure-cli/synapse/deploy.ps1
+++ b/azure-cli/synapse/deploy.ps1
@@ -34,7 +34,7 @@ param (
 Write-Host "Provision synapse workspace" -ForegroundColor DarkGreen
 
 # import utility functions
-. "$PSScriptRoot\..\_common\utilities\get_NewPassword.ps1"
+. "$PSScriptRoot\..\utilities\New-Password.ps1"
 
 #############################################################################################
 # Resource naming section
@@ -56,7 +56,7 @@ $synapseServerPassword = az keyvault secret show `
 
 if (!$?) {
   Write-Host "  Creating SynapseServerPassword secret" -ForegroundColor DarkYellow
-  $synapseServerPassword = Get-NewPassword
+  $synapseServerPassword = New-Password -Length 20
   $output = az keyvault secret set `
     --vault-name $keyVaultName `
     --name "SynapseServerPassword" `

--- a/azure-cli/utilities/New-Password.ps1
+++ b/azure-cli/utilities/New-Password.ps1
@@ -6,6 +6,10 @@ function New-Password {
     [int]
     $PasswordLength,
 
+    [Parameter(Mandatory = $false)]
+    [string]
+    $AvoidCharacters,
+
     [switch]
     $NoSpecialCharacters
   )
@@ -21,6 +25,13 @@ function New-Password {
     # https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
     $specialCharacters = [char]33..[char]47 + [char]58..[char]64 + [char]91..[char]96 + [char]123..[char]126
     $availableCharacters += $specialCharacters
+  }
+
+  # Remove any characters that the caller explicitly don't want in their password.
+  # SQL Server, for example, does not allow single quotes in passwords by default.
+  if ($AvoidCharacters) {
+    $unavailableCharacters = $AvoidCharacters.ToCharArray()
+    $availableCharacters = $availableCharacters | Where-Object { $unavailableCharacters -notcontains $_ }
   }
 
   # Generate a new random password until we hit one that contains all of the following criteria:

--- a/azure-cli/utilities/New-Password.ps1
+++ b/azure-cli/utilities/New-Password.ps1
@@ -1,0 +1,51 @@
+function New-Password {
+  param (
+    [Parameter(Mandatory = $true)]
+    [ValidateRange(4, 4096)]
+    [Alias("Length")]
+    [int]
+    $PasswordLength,
+
+    [switch]
+    $NoSpecialCharacters
+  )
+
+  $upperCaseCharacters = [char]65..[char]90
+  $lowerCaseCharacters = [char]97..[char]122
+  $numbers = [char]48..[char]57
+
+  $availableCharacters = $upperCaseCharacters + $lowerCaseCharacters + $numbers
+
+  if (-not $NoSpecialCharacters.IsPresent) {
+    # The special characters array will contain ~!@#$%^&*_-+=`|\(){}[]:;"'<>,.?/ as listed in
+    # https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
+    $specialCharacters = [char]33..[char]47 + [char]58..[char]64 + [char]91..[char]96 + [char]123..[char]126
+    $availableCharacters += $specialCharacters
+  }
+
+  # Generate a new random password until we hit one that contains all of the following criteria:
+  # a number, a lower-case character, an upper-case character, and a special character (if not disabled).
+  $passesComplexityCheck = $false
+
+  do {
+    $passwordCharacters = @()
+
+    for ($i = 0; $i -lt $PasswordLength; $i++) {
+      $passwordCharacters += $availableCharacters | Get-Random
+    }
+
+    $password = -join $passwordCharacters
+
+    $passesComplexityCheck = `
+      $password -cmatch "[A-Z\p{Lu}\s]" -and `
+      $password -cmatch "[a-z\p{Ll}\s]" -and `
+      $password -match "[\d]"
+
+    if ($passesComplexityCheck -and -not $NoSpecialCharacters.IsPresent) {
+      $passesComplexityCheck = $password -match "[^\w]|_"
+    }
+		
+  } while (-not $passesComplexityCheck)
+
+  return $password
+}

--- a/azure-cli/utilities/New-Password.ps1
+++ b/azure-cli/utilities/New-Password.ps1
@@ -10,9 +10,9 @@ function New-Password {
     $NoSpecialCharacters
   )
 
-  $upperCaseCharacters = [char]65..[char]90
-  $lowerCaseCharacters = [char]97..[char]122
-  $numbers = [char]48..[char]57
+  $upperCaseCharacters = [char]'A'..[char]'Z'
+  $lowerCaseCharacters = [char]'a'..[char]'z'
+  $numbers = [char]'0'..[char]'9'
 
   $availableCharacters = $upperCaseCharacters + $lowerCaseCharacters + $numbers
 

--- a/azure-cli/utilities/get_NewPassword.ps1
+++ b/azure-cli/utilities/get_NewPassword.ps1
@@ -1,5 +1,0 @@
-function Get-NewPassword {
-  $guid1 = [System.Guid]::NewGuid().ToString().Substring(0, 8)
-  $guid2 = [System.Guid]::NewGuid().ToString().ToUpper().Substring(0, 8)
-  return $guid1 + $guid2
-}


### PR DESCRIPTION
Replaces the old [`Get-NewPassword`](https://github.com/atc-net/atc-snippets/blob/b9211c631c9555c77d0ce08f6bd90b04be0cb833/azure-cli/utilities/get_NewPassword.ps1) function that never was a real password generator function in the first place.