### PR TITLE
fix: handle powershell quirk where string[] of 1 converts to string

### DIFF
--- a/azure-cli/network/Select-FreeSubnetRange.ps1
+++ b/azure-cli/network/Select-FreeSubnetRange.ps1
@@ -19,7 +19,11 @@ function Select-FreeSubnetRange {
     --vnet-name $VnetName `
     --query "[].addressPrefix"
 
-  $subnets = $subnets | ConvertFrom-Json
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to get subnet list for VNet '$VnetName' in resource group '$ResourceGroupName'`n$subnets"
+  }
+
+  [array]$subnets = $subnets | ConvertFrom-Json
 
   # Check if there is any subnets to begin with
   if ($subnets.Count -eq 0) {


### PR DESCRIPTION
If the returned subnet list contains exactly 1 subnet, `ConvertFrom-Json` converts the json array to a string.
When the `$subnets` variable is a string instead of an array, the script breaks because it's accessing indexes in the array.